### PR TITLE
Get

### DIFF
--- a/class_Project/rest_methods.js
+++ b/class_Project/rest_methods.js
@@ -1,9 +1,18 @@
+/*
+Contributors: 
+Anthony Martinez
+Michael Munoz
+
+Updated on 03/25/2017
+*/
+
 const CREATED_TOKEN_STATUS = 201;
 const SUCCESS_STATUS = 200;
 const ERROR_STATUS = 400; 
 const JWT_EXPIRATION_TIME = '5h';
 const SERVER_PORT = 8080;
-const STARTING_POSITION_OF_INNER_QUERY = 7
+const STARTING_POSITION_OF_INNER_QUERY = 7;
+const SALT_LENGTH = 32;
 
 var express = require("express");
 var mysql = require('mysql');
@@ -16,11 +25,11 @@ var connection = mysql.createConnection({
 var fileSystem = require('fs');
 var jwt = require('jsonwebtoken');
 var bodyParser = require('body-parser');
+var crypto = require('crypto');
 var app = express();
 
 app.get("/", function(req,res){
-
- res.send("welcome to cecs.me");
+  res.send("welcome to cecs.me");
 });
 
 
@@ -30,21 +39,30 @@ app.use(bodyParser.urlencoded({
 }));
 
 var secret = fileSystem.readFileSync('secret.txt', 'utf8');
+
 app.post("/register", function(req, res) {
   
   //check if data was supplied
   if(!req.body)
     return res.status(ERROR_STATUS).send({'response': 'Error', 'error': 'Parameter is undefined'});
 
-  var addNewUserQuery = "INSERT INTO users (username, password) VALUES (\"" + req.body.username + "\", \"" + req.body.password +"\");";
+  //create random bytes, up to 32 bits in length
+  var salt = crypto.randomBytes(SALT_LENGTH).toString('hex').slice(0,SALT_LENGTH);
+
+  //use sha512 and the salt
+  var passwordHasher = crypto.createHmac('sha512', salt);
+  //hash the passsword
+  passwordHasher.update(req.body.password);
+  var hashed = passwordHasher.digest('hex');
+
+  var addNewUserQuery = "INSERT INTO users (username, password, salt) VALUES (\"" + req.body.username + "\", \"" + hashed +"\", \"" + salt + "\");";
+
   connection.query(addNewUserQuery, function(err, results, fields) {
     if (err)
       //error occured, exit function
       return res.status(ERROR_STATUS).send({'response': 'Error', 'error': "DB `Error: " + err});
     else {
-      //create jwt token
-      var secret = fileSystem.readFileSync('secret.txt', 'utf8');
-      //token is encoded with hmac SHA256 by default
+      //create jwt token, token is encoded with hmac SHA256 by default
       var jwtToken = jwt.sign({'username': req.body.username}, secret, { expiresIn: JWT_EXPIRATION_TIME});
       return res.status(CREATED_TOKEN_STATUS).send({'response': 'Success', 'message': "JWT token generated and user register", 'jwtToken':jwtToken});   
     }
@@ -57,23 +75,30 @@ app.post("/signIn", function(req, res) {
   //check if the parameter data was supplied
   if(!req.body)
     return res.status(ERROR_STATUS).send({'response': 'Error', 'error': 'Parameter is undefined'});
+
+  var passwordAndSaltQuery = "SELECT * FROM users WHERE username=\"" + req.body.username +"\";"
   
-  //check here if password and username are the same in database
-  var signInQuery="SELECT EXISTS (SELECT 1 FROM users WHERE username=\"" + req.body.username + "\" AND password=\"" + req.body.password + "\");";
-  connection.query(signInQuery, function(err, results, fields) {
-    if (err)
-      //error occures, exit function
+  connection.query(passwordAndSaltQuery, function(err, results, fields) {
+    if(err)
       return res.status(ERROR_STATUS).send({'response': 'Error', 'error': "DB Error: " + err});
-    else//db returns results in an index that is titled the query
-      if(results[0][signInQuery.substring(STARTING_POSITION_OF_INNER_QUERY, signInQuery.length - 1)]) {
-        //create jwt token
-        var secret = fileSystem.readFileSync('secret.txt', 'utf8');
-        //token is encoded with hmac SHA256 by default     CHANGEMEBACK
-        var jwtToken = jwt.sign({'username': req.body.username}, secret, { expiresIn: JWT_EXPIRATION_TIME});
-        return res.status(CREATED_TOKEN_STATUS).send({'response': 'Success', 'message': "JWT token generated and user signed in", 'jwtToken':jwtToken});   
-      }
-      else 
+    else {
+      if(!results.length)//if the user does not exist in database
         return res.status(ERROR_STATUS).send({'response': 'Error', 'error': 'Incorrect username or password'});
+      else {        
+        //use sha512 and the salt
+        var passwordHasher = crypto.createHmac('sha512', results[0]['salt']);
+        //hash the passsword
+        passwordHasher.update(req.body.password);
+        var hashed = passwordHasher.digest('hex');
+        //if the password hashed matches the one stored for the user then send them a jwt token
+        if(hashed === results[0]['password']) {//create jwt token token is encoded with hmac SHA256 by default
+          var jwtToken = jwt.sign({'username': req.body.username}, secret, { expiresIn: JWT_EXPIRATION_TIME});
+          return res.status(CREATED_TOKEN_STATUS).send({'response': 'Success', 'message': "JWT token generated and user signed in", 'jwtToken':jwtToken});  
+        }
+        else //passwords did not match
+          return res.status(ERROR_STATUS).send({'response': 'Error', 'error': 'Incorrect username or password'});
+      }
+    }
   });
 });
 


### PR DESCRIPTION
Passwords are now hashed on the server side so that when a user
uninstall the application they do not loose their account, since the
salt is saved in the server.
Register: now hashes the password with salt and saves the output with
the salt to the db.
Sign in: checks if the user provided password hashes the same results
saved in the db after the same salt is applied.